### PR TITLE
Add Azure OpenAI LLM support

### DIFF
--- a/README.CN.md
+++ b/README.CN.md
@@ -80,7 +80,7 @@
   - 🌍 TTS 翻译支持（例如，用中文聊天的同时，AI 使用日语声音）
 
 - 🧠 **广泛的模型支持**：
-  - 🤖 大语言模型 (LLM)：Ollama、OpenAI（以及任何与 OpenAI 兼容的 API）、Gemini、Claude、Mistral、DeepSeek、智谱、GGUF、LM Studio、vLLM 等
+  - 🤖 大语言模型 (LLM)：Ollama、OpenAI（以及任何与 OpenAI 兼容的 API）、Azure OpenAI、Gemini、Claude、Mistral、DeepSeek、智谱、GGUF、LM Studio、vLLM 等
   - 🎙️ 语音识别 (ASR)：sherpa-onnx、FunASR、Faster-Whisper、Whisper.cpp、Whisper、Groq Whisper、Azure ASR等
   - 🔊 语音合成 (TTS)：sherpa-onnx、pyttsx3、MeloTTS、Coqui-TTS、GPTSoVITS、Bark、CosyVoice、Edge TTS、Fish Audio、Azure TTS等
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This project underwent code refactoring after version `v1.0.0` and is currently 
   - 🌍 TTS translation support (e.g., chat in Chinese while AI uses Japanese voice)
 
 - 🧠 **Extensive model support**:
-  - 🤖 Large Language Models (LLM): Ollama, OpenAI (and any OpenAI-compatible API), Gemini, Claude, Mistral, DeepSeek, Zhipu AI, GGUF, LM Studio, vLLM, etc.
+  - 🤖 Large Language Models (LLM): Ollama, OpenAI (and any OpenAI-compatible API), Azure OpenAI, Gemini, Claude, Mistral, DeepSeek, Zhipu AI, GGUF, LM Studio, vLLM, etc.
   - 🎙️ Automatic Speech Recognition (ASR): sherpa-onnx, FunASR, Faster-Whisper, Whisper.cpp, Whisper, Groq Whisper, Azure ASR, etc.
   - 🔊 Text-to-Speech (TTS): sherpa-onnx, pyttsx3, MeloTTS, Coqui-TTS, GPTSoVITS, Bark, CosyVoice, Edge TTS, Fish Audio, Azure TTS, etc.
 

--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -6,7 +6,7 @@
 
 # 系统设置：与服务器初始化相关的设置
 system_config:
-  conf_version: 'v1.1.1' # 配置文件版本
+  conf_version: 'v1.1.0-alpha.1' # 配置文件版本
   host: 'localhost' # 服务器监听的地址，'0.0.0.0' 表示监听所有网络接口；如果需要安全，可以使用 '127.0.0.1'（仅本地访问）
   port: 12393 # 服务器监听的端口
   config_alts_dir: 'characters' # 用于存放替代配置的目录
@@ -48,7 +48,7 @@ character_config:
         # 例如：
         # 'openai_compatible_llm', 'llama_cpp_llm', 'claude_llm', 'ollama_llm'
         # 'openai_llm', 'gemini_llm', 'zhipu_llm', 'deepseek_llm', 'groq_llm'
-        # 'mistral_llm'
+        # 'mistral_llm', 'azure_openai_llm'
         llm_provider: 'ollama_llm' # 使用的 LLM 提供商
         # 是否在第一句回应时遇上逗号就直接生成音频以减少首句延迟（默认：True）
         faster_first_response: True
@@ -127,6 +127,13 @@ character_config:
       openai_llm:
         llm_api_key: 'Your Open AI API key' # OpenAI API 密钥
         model: 'gpt-4o' # 使用的模型
+        temperature: 1.0 # 温度，介于 0 到 2 之间
+
+      azure_openai_llm:
+        azure_endpoint: 'https://your-azure-endpoint/' # Azure OpenAI 端点
+        deployment_name: 'your-deployment' # 部署名称
+        api_version: '2024-12-01-preview' # API 版本
+        llm_api_key: 'Your Azure API key' # Azure API 密钥
         temperature: 1.0 # 温度，介于 0 到 2 之间
 
       gemini_llm:

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -1,6 +1,6 @@
 # System Settings: Setting related to the initialization of the server
 system_config:
-  conf_version: 'v1.1.1'
+  conf_version: 'v1.1.0-alpha.1'
   host: 'localhost' # use 0.0.0.0 if you want other devices to access this page
   port: 12393
   # New setting for alternative configurations
@@ -47,7 +47,7 @@ character_config:
         # examples: 
         # 'openai_compatible_llm', 'llama_cpp_llm', 'claude_llm', 'ollama_llm'
         # 'openai_llm', 'gemini_llm', 'zhipu_llm', 'deepseek_llm', 'groq_llm'
-        # 'mistral_llm'
+        # 'mistral_llm', 'azure_openai_llm'
         llm_provider: 'ollama_llm'
         # let ai speak as soon as the first comma is received on the first sentence
         # to reduced latency.
@@ -128,6 +128,13 @@ character_config:
       openai_llm:
         llm_api_key: 'Your Open AI API key'
         model: 'gpt-4o'
+        temperature: 1.0 # value between 0 to 2
+
+      azure_openai_llm:
+        azure_endpoint: 'https://your-azure-endpoint/'
+        deployment_name: 'your-deployment'
+        api_version: '2024-12-01-preview'
+        llm_api_key: 'Your Azure API key'
         temperature: 1.0 # value between 0 to 2
 
       gemini_llm:

--- a/src/open_llm_vtuber/agent/stateless_llm/azure_openai_llm.py
+++ b/src/open_llm_vtuber/agent/stateless_llm/azure_openai_llm.py
@@ -1,0 +1,77 @@
+"""Azure OpenAI asynchronous LLM implementation."""
+
+from typing import AsyncIterator, List, Dict, Any
+from openai import AsyncAzureOpenAI, APIError, APIConnectionError, RateLimitError
+from loguru import logger
+
+from .stateless_llm_interface import StatelessLLMInterface
+
+
+class AsyncLLM(StatelessLLMInterface):
+    def __init__(
+        self,
+        deployment_name: str,
+        azure_endpoint: str,
+        api_version: str,
+        llm_api_key: str,
+        temperature: float = 1.0,
+    ) -> None:
+        """Initialize Azure OpenAI LLM."""
+        self.deployment_name = deployment_name
+        self.temperature = temperature
+        self.client = AsyncAzureOpenAI(
+            api_version=api_version,
+            azure_endpoint=azure_endpoint,
+            api_key=llm_api_key,
+        )
+        logger.info(
+            "Initialized Azure OpenAI AsyncLLM with endpoint: %s, deployment: %s",
+            azure_endpoint,
+            deployment_name,
+        )
+
+    async def chat_completion(
+        self, messages: List[Dict[str, Any]], system: str | None = None
+    ) -> AsyncIterator[str]:
+        """Generate chat completion using Azure OpenAI."""
+        messages_with_system = messages
+        if system:
+            messages_with_system = [
+                {"role": "system", "content": system},
+                *messages,
+            ]
+        stream = None
+        try:
+            stream = await self.client.chat.completions.create(
+                messages=messages_with_system,
+                model=self.deployment_name,
+                temperature=self.temperature,
+                stream=True,
+            )
+            async for chunk in stream:
+                if chunk.choices[0].delta.content is None:
+                    chunk.choices[0].delta.content = ""
+                yield chunk.choices[0].delta.content
+        except APIConnectionError as e:
+            logger.error(
+                "Error calling the chat endpoint: Connection error. %s",
+                e,
+            )
+            yield (
+                "Error calling the chat endpoint: Connection error. "
+                "Failed to connect to the LLM API."
+            )
+        except RateLimitError as e:
+            logger.error(
+                "Error calling the chat endpoint: Rate limit exceeded: {}",
+                e.response,
+            )
+            yield "Error calling the chat endpoint: Rate limit exceeded. Please try again later."
+        except APIError as e:
+            logger.error("Azure LLM API error occurred: {}", e)
+            yield "Error calling the chat endpoint: Error occurred while generating response."
+        finally:
+            if stream:
+                logger.debug("Chat completion finished.")
+                await stream.close()
+                logger.debug("Stream closed.")

--- a/src/open_llm_vtuber/agent/stateless_llm_factory.py
+++ b/src/open_llm_vtuber/agent/stateless_llm_factory.py
@@ -35,6 +35,16 @@ class LLMFactory:
                 organization_id=kwargs.get("organization_id"),
                 project_id=kwargs.get("project_id"),
             )
+        if llm_provider == "azure_openai_llm":
+            from .stateless_llm.azure_openai_llm import AsyncLLM as AzureAsyncLLM
+
+            return AzureAsyncLLM(
+                deployment_name=kwargs.get("deployment_name"),
+                azure_endpoint=kwargs.get("azure_endpoint"),
+                api_version=kwargs.get("api_version"),
+                llm_api_key=kwargs.get("llm_api_key"),
+                temperature=kwargs.get("temperature"),
+            )
         if llm_provider == "ollama_llm":
             return OllamaLLM(
                 model=kwargs.get("model"),

--- a/src/open_llm_vtuber/config_manager/agent.py
+++ b/src/open_llm_vtuber/config_manager/agent.py
@@ -25,6 +25,7 @@ class BasicMemoryAgentConfig(I18nMixin, BaseModel):
         "deepseek_llm",
         "groq_llm",
         "mistral_llm",
+        "azure_openai_llm",
     ] = Field(..., alias="llm_provider")
 
     faster_first_response: Optional[bool] = Field(True, alias="faster_first_response")

--- a/src/open_llm_vtuber/config_manager/stateless_llm.py
+++ b/src/open_llm_vtuber/config_manager/stateless_llm.py
@@ -140,6 +140,35 @@ class GroqConfig(OpenAICompatibleConfig):
     )
 
 
+class AzureOpenAIConfig(StatelessLLMBaseConfig):
+    """Configuration for Azure OpenAI API."""
+
+    azure_endpoint: str = Field(..., alias="azure_endpoint")
+    llm_api_key: str = Field(..., alias="llm_api_key")
+    api_version: str = Field(..., alias="api_version")
+    deployment_name: str = Field(..., alias="deployment_name")
+    temperature: float = Field(1.0, alias="temperature")
+
+    _AZURE_DESCRIPTIONS: ClassVar[dict[str, Description]] = {
+        "azure_endpoint": Description(
+            en="Azure endpoint for the OpenAI resource",
+            zh="Azure OpenAI 端点",
+        ),
+        "llm_api_key": Description(en="API key for authentication", zh="API 认证密钥"),
+        "api_version": Description(en="Azure OpenAI API version", zh="Azure OpenAI API 版本"),
+        "deployment_name": Description(en="Deployment name", zh="部署名称"),
+        "temperature": Description(
+            en="What sampling temperature to use, between 0 and 2.",
+            zh="使用的采样温度，介于 0 和 2 之间。",
+        ),
+    }
+
+    DESCRIPTIONS: ClassVar[dict[str, Description]] = {
+        **StatelessLLMBaseConfig.DESCRIPTIONS,
+        **_AZURE_DESCRIPTIONS,
+    }
+
+
 class ClaudeConfig(StatelessLLMBaseConfig):
     """Configuration for OpenAI Official API."""
 
@@ -202,6 +231,7 @@ class StatelessLLMConfigs(I18nMixin, BaseModel):
     claude_llm: ClaudeConfig | None = Field(None, alias="claude_llm")
     llama_cpp_llm: LlamaCppConfig | None = Field(None, alias="llama_cpp_llm")
     mistral_llm: MistralConfig | None = Field(None, alias="mistral_llm")
+    azure_openai_llm: AzureOpenAIConfig | None = Field(None, alias="azure_openai_llm")
 
     DESCRIPTIONS: ClassVar[dict[str, Description]] = {
         "openai_compatible_llm": Description(
@@ -228,5 +258,8 @@ class StatelessLLMConfigs(I18nMixin, BaseModel):
         ),
         "llama_cpp_llm": Description(
             en="Configuration for local Llama.cpp", zh="本地Llama.cpp配置"
+        ),
+        "azure_openai_llm": Description(
+            en="Configuration for Azure OpenAI API", zh="Azure OpenAI API 配置"
         ),
     }


### PR DESCRIPTION
## Summary
- support Azure OpenAI as an LLM provider
- document the new provider in README files
- expose Azure OpenAI config fields
- update configuration templates
- add provider to factory and config schemas
- fix logging for Azure errors
- set template conf_version to v1.1.0-alpha.1

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_6863b47a8bb88329973a4500cc04e5fc