### PR TITLE
Fix MERaLiON ASR extra colon

### DIFF
--- a/config_templates/conf.ZH.default.yaml
+++ b/config_templates/conf.ZH.default.yaml
@@ -163,7 +163,7 @@ character_config:
 
   # === 自动语音识别 ===
   asr_config:
-    # 语音转文本模型选项：'faster_whisper', 'whisper_cpp', 'whisper', 'azure_asr', 'fun_asr', 'groq_whisper_asr', 'sherpa_onnx_asr'
+    # 语音转文本模型选项：'faster_whisper', 'whisper_cpp', 'whisper', 'azure_asr', 'fun_asr', 'groq_whisper_asr', 'sherpa_onnx_asr', 'meralion_asr'
     asr_model: 'sherpa_onnx_asr' # 使用的语音识别模型
 
     azure_asr:
@@ -246,6 +246,10 @@ character_config:
       use_itn: True # 对 SenseVoice 模型启用 ITN（如果不是 SenseVoice 模型，则应设置为 False）
       # 推理平台（cpu 或 cuda）(cuda 需要额外配置，请参考文档)
       provider: 'cpu'
+
+    meralion_asr:
+      model_path: './models/meralion'
+      device: 'auto'
 
     groq_whisper_asr:
       api_key: ''

--- a/config_templates/conf.default.yaml
+++ b/config_templates/conf.default.yaml
@@ -164,7 +164,7 @@ character_config:
 
   # === Automatic Speech Recognition ===
   asr_config:
-    # speech to text model options: 'faster_whisper', 'whisper_cpp', 'whisper', 'azure_asr', 'fun_asr', 'groq_whisper_asr', 'sherpa_onnx_asr'
+    # speech to text model options: 'faster_whisper', 'whisper_cpp', 'whisper', 'azure_asr', 'fun_asr', 'groq_whisper_asr', 'sherpa_onnx_asr', 'meralion_asr'
     asr_model: 'sherpa_onnx_asr'
 
     azure_asr:
@@ -249,7 +249,11 @@ character_config:
       # feature_dim: 80       # Feature dimension (should match the model's expected feature dimension)
       use_itn: True # Enable ITN for SenseVoice models (should set to False if not using SenseVoice models)
       # Provider for inference (cpu or cuda) (cuda option needs additional settings. Please check our docs)
-      provider: 'cpu' 
+      provider: 'cpu'
+
+    meralion_asr:
+      model_path: './models/meralion'
+      device: 'auto'
 
     groq_whisper_asr:
       api_key: ''

--- a/src/open_llm_vtuber/asr/asr_factory.py
+++ b/src/open_llm_vtuber/asr/asr_factory.py
@@ -56,5 +56,12 @@ class ASRFactory:
             from .sherpa_onnx_asr import VoiceRecognition as SherpaOnnxASR
 
             return SherpaOnnxASR(**kwargs)
+        elif system_name == "meralion_asr":
+            from .meralion_asr import VoiceRecognition as MERaLiONASR
+
+            return MERaLiONASR(
+                model_path=kwargs.get("model_path"),
+                device=kwargs.get("device"),
+            )
         else:
             raise ValueError(f"Unknown ASR system: {system_name}")

--- a/src/open_llm_vtuber/asr/meralion_asr.py
+++ b/src/open_llm_vtuber/asr/meralion_asr.py
@@ -1,0 +1,60 @@
+import numpy as np
+import re
+import torch
+from transformers import AutoModelForSpeechSeq2Seq, AutoProcessor
+
+from .asr_interface import ASRInterface
+
+
+class VoiceRecognition(ASRInterface):
+    """MERaLiON ASR implementation using Hugging Face models."""
+
+    def __init__(self, model_path: str, device: str = "auto") -> None:
+        if device == "auto":
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = device
+        self.processor = AutoProcessor.from_pretrained(
+            model_path, trust_remote_code=True
+        )
+        self.model = AutoModelForSpeechSeq2Seq.from_pretrained(
+            model_path,
+            use_safetensors=True,
+            trust_remote_code=True,
+            torch_dtype=torch.float16 if self.device == "cuda" else torch.float32,
+        ).to(self.device)
+
+    def transcribe_np(self, audio: np.ndarray) -> str:
+        audio_list = [audio]
+        prompt_template = "Instruction: {query} \nFollow the text instruction based on the following audio: <SpeechHere>"
+        transcribe_prompt = "Please transcribe this speech."
+        conversation = [
+            [
+                {
+                    "role": "user",
+                    "content": prompt_template.format(query=transcribe_prompt),
+                }
+            ]
+        ]
+        chat_prompt = self.processor.tokenizer.apply_chat_template(
+            conversation=conversation, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self.processor(text=chat_prompt, audios=audio_list)
+        for key, value in inputs.items():
+            if isinstance(value, torch.Tensor):
+                inputs[key] = value.to(self.device)
+                if value.dtype == torch.float32 and self.device == "cuda":
+                    inputs[key] = inputs[key].to(torch.float16)
+        outputs = self.model.generate(
+            **inputs,
+            max_new_tokens=128,
+            do_sample=False,
+            num_beams=1,
+        )
+        generated_ids = outputs[:, inputs["input_ids"].size(1) :]
+        response = self.processor.batch_decode(generated_ids, skip_special_tokens=True)
+        text = response[0].strip()
+        # Remove common prefixes like "Assistant:" that the model may generate
+        text = re.sub(r"^\s*\w+:\s*", "", text)
+        if text.startswith(":"):
+            text = text[1:].lstrip()
+        return text

--- a/src/open_llm_vtuber/config_manager/asr.py
+++ b/src/open_llm_vtuber/config_manager/asr.py
@@ -276,6 +276,23 @@ class SherpaOnnxASRConfig(I18nMixin):
         return values
 
 
+class MERaLiONASRConfig(I18nMixin):
+    """Configuration for MERaLiON ASR."""
+
+    model_path: str = Field(..., alias="model_path")
+    device: Literal["auto", "cpu", "cuda"] = Field("auto", alias="device")
+
+    DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
+        "model_path": Description(
+            en="Path to the MERaLiON model", zh="MERaLiON 模型路径"
+        ),
+        "device": Description(
+            en="Device for inference (auto, cpu, or cuda)",
+            zh="用于推理的设备 (auto、cpu 或 cuda)",
+        ),
+    }
+
+
 class ASRConfig(I18nMixin):
     """Configuration for Automatic Speech Recognition."""
 
@@ -287,6 +304,7 @@ class ASRConfig(I18nMixin):
         "fun_asr",
         "groq_whisper_asr",
         "sherpa_onnx_asr",
+        "meralion_asr",
     ] = Field(..., alias="asr_model")
     azure_asr: Optional[AzureASRConfig] = Field(None, alias="azure_asr")
     faster_whisper: Optional[FasterWhisperConfig] = Field(None, alias="faster_whisper")
@@ -299,6 +317,7 @@ class ASRConfig(I18nMixin):
     sherpa_onnx_asr: Optional[SherpaOnnxASRConfig] = Field(
         None, alias="sherpa_onnx_asr"
     )
+    meralion_asr: Optional[MERaLiONASRConfig] = Field(None, alias="meralion_asr")
 
     DESCRIPTIONS: ClassVar[Dict[str, Description]] = {
         "asr_model": Description(
@@ -318,6 +337,9 @@ class ASRConfig(I18nMixin):
         ),
         "sherpa_onnx_asr": Description(
             en="Configuration for Sherpa Onnx ASR", zh="Sherpa Onnx ASR 配置"
+        ),
+        "meralion_asr": Description(
+            en="Configuration for MERaLiON ASR", zh="MERaLiON ASR 配置"
         ),
     }
 
@@ -340,5 +362,7 @@ class ASRConfig(I18nMixin):
             values.groq_whisper_asr.model_validate(values.groq_whisper_asr.model_dump())
         elif asr_model == "SherpaOnnxASR" and values.sherpa_onnx_asr is not None:
             values.sherpa_onnx_asr.model_validate(values.sherpa_onnx_asr.model_dump())
+        elif asr_model == "MERaLiONASR" and values.meralion_asr is not None:
+            values.meralion_asr.model_validate(values.meralion_asr.model_dump())
 
         return values


### PR DESCRIPTION
## Summary
- clean MERaLiON ASR output to remove leading prefixes like `Assistant:` or stray colons

## Testing
- `ruff format src/open_llm_vtuber/asr/meralion_asr.py`
- `ruff check src/open_llm_vtuber/asr/meralion_asr.py`


------
https://chatgpt.com/codex/tasks/task_e_6883417f867c83298f9a4bed79f8c151